### PR TITLE
fix: threshold property

### DIFF
--- a/src/Web/IntersectionObserver.purs
+++ b/src/Web/IntersectionObserver.purs
@@ -20,13 +20,13 @@ type IntersectionObserverInit' =
   , rootMargin :: String
 
   -- | ```js
-  -- | var obs = new IntersectionObserver(() => {}, { thresholds: [] })`
-  -- | console.log(obs.thresholds)
+  -- | var obs = new IntersectionObserver(() => {}, { threshold: [] })`
+  -- | console.log(obs.threshold)
   -- | ```
   -- | will output [0]
   -- |
   -- | so, maybe replace type to `NonEmpty Array Number`?
-  , thresholds :: Array Number
+  , threshold :: Array Number
   }
 
 data IntersectionObserverInitRoot
@@ -42,14 +42,14 @@ intersectionObserverInitRootToInternal (Document document) = toNullable <<< Just
 type IntersectionObserverInit =
   { root :: IntersectionObserverInitRoot
   , rootMargin :: String
-  , thresholds :: Array Number
+  , threshold :: Array Number
   }
 
 defaultIntersectionObserverInit :: IntersectionObserverInit
 defaultIntersectionObserverInit =
   { root: None
   , rootMargin: "0px"
-  , thresholds: [0.0]
+  , threshold: [0.0]
   }
 
 foreign import _create :: EFn.EffectFn2 (EFn.EffectFn2 (Array IntersectionObserverEntry) IntersectionObserver Unit) IntersectionObserverInit' IntersectionObserver


### PR DESCRIPTION
Rename `thresholds` property to `threshold`. From MDN:

> Be careful! Although the options object you can specify when creating an IntersectionObserver has a field named threshold, this property is called thresholds. Confusing? Yes. If you accidentally use thresholds as the name of the field in your options, the thresholds array will wind up being simply [0.0], which is likely not what you expect. Debugging chaos may ensue.


https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver/thresholds